### PR TITLE
Track finding

### DIFF
--- a/Examples/Algorithms/Fitting/CMakeLists.txt
+++ b/Examples/Algorithms/Fitting/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   ActsExamplesFitting SHARED
   src/FittingAlgorithm.cpp
   src/TrkrClusterFittingAlgorithmFitterFunction.cpp
+  src/TrkrClusterFindingAlgorithmFinderFunction.cpp
   src/FittingAlgorithmFitterFunction.cpp)
 target_include_directories(
   ActsExamplesFitting

--- a/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
+++ b/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
@@ -1,0 +1,65 @@
+
+#include <iostream>
+#include <map>
+#include <random>
+#include <stdexcept>
+#include <boost/program_options.hpp>
+
+#include <Acts/Fitter/GainMatrixSmoother.hpp>
+#include <Acts/Fitter/GainMatrixUpdater.hpp>
+#include <Acts/Geometry/GeometryID.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/MagneticField/SharedBField.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+#include <Acts/TrackFinder/CKFSourceLinkSelector.hpp>
+#include <Acts/TrackFinder/CombinatorialKalmanFilter.hpp>
+#include <Acts/Geometry/TrackingGeometry.hpp>
+
+#include "ACTFW/Plugins/BField/ScalableBField.hpp"
+#include "ACTFW/EventData/Track.hpp"
+#include "ACTFW/Framework/BareAlgorithm.hpp"
+#include "ACTFW/Plugins/BField/BFieldOptions.hpp"
+#include "ACTFW/EventData/TrkrClusterSourceLink.hpp"
+
+using SourceLink = FW::Data::TrkrClusterSourceLink;
+
+namespace FW{
+
+  class TrkrClusterFindingAlgorithm final : public FW::BareAlgorithm
+  {
+
+  public:
+    using FinderResult = 
+      Acts::Result<Acts::CombinatorialKalmanFilterResult<SourceLink>>;
+
+    using FinderFunction 
+      = std::function<FinderResult(const std::vector<SourceLink>&,
+				   const FW::TrackParameters&,
+				   const Acts::CombinatorialKalmanFilterOptions<Acts::VoidBranchStopper>&)>;
+
+    static FinderFunction
+      makeFinderFunction(
+	 std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+	 FW::Options::BFieldVariant magneticField,
+	 Acts::Logging::Level level);
+
+    struct Config
+    {
+      FinderFunction finder;
+    };
+
+    TrkrClusterFindingAlgorithm(Config cfg, Acts::Logging::Level lvl);
+
+  private:
+    Config m_cfg;
+
+  };
+
+
+}

--- a/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
+++ b/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
@@ -41,7 +41,7 @@ namespace FW{
     using FinderFunction 
       = std::function<FinderResult(const std::vector<SourceLink>&,
 				   const FW::TrackParameters&,
-				   const Acts::CombinatorialKalmanFilterOptions<Acts::VoidBranchStopper>&)>;
+				   const Acts::CombinatorialKalmanFilterOptions<Acts::CKFSourceLinkSelector>&)>;
 
     static FinderFunction
       makeFinderFunction(

--- a/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
+++ b/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
@@ -46,7 +46,7 @@ public:
 
   /// Create fitter function
   static FitterFunction
-  makeFitterFunction(
+    makeFitterFunction(
       std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
       FW::Options::BFieldVariant                    magneticField,
       Acts::Logging::Level                          lvl);

--- a/Examples/Algorithms/Fitting/src/TrkrClusterFindingAlgorithmFinderFunction.cpp
+++ b/Examples/Algorithms/Fitting/src/TrkrClusterFindingAlgorithmFinderFunction.cpp
@@ -1,0 +1,80 @@
+#include "ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp"
+
+#include <Acts/Fitter/GainMatrixSmoother.hpp>
+#include <Acts/Fitter/GainMatrixUpdater.hpp>
+#include <Acts/Geometry/GeometryID.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/MagneticField/SharedBField.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+
+/**
+ * Struct that calls the finding algorithm to get the result of the track
+ * propagation/finding
+ */
+namespace {
+  template <typename Finder>
+  struct TrkrFindingFunctionImpl
+  {
+    Finder finder;
+
+    TrkrFindingFunctionImpl(Finder&& f) : finder(std::move(f)) {}
+
+    FW::TrkrClusterFindingAlgorithm::FinderResult
+    operator()(
+       const std::vector<SourceLink>& sourceLinks,
+       const FW::TrackParameters&                          initialParameters,
+       const Acts::CombinatorialKalmanFilterOptions<Acts::VoidBranchStopper>&       options) const
+    {
+      /// Call CombinatorialKalmanFilter findTracks
+      return finder.findTracks(sourceLinks, initialParameters, options);
+    };
+  };
+}  // namespace
+
+/**
+ * Function that actually makes the track finding function to be used 
+ */
+FW::TrkrClusterFindingAlgorithm::FinderFunction
+FW::TrkrClusterFindingAlgorithm::makeFinderFunction(
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+    FW::Options::BFieldVariant                    magneticField,
+    Acts::Logging::Level                          level)
+{
+  using Updater  = Acts::GainMatrixUpdater<Acts::BoundParameters>;
+  using Smoother = Acts::GainMatrixSmoother<Acts::BoundParameters>;
+
+  /// Return a new instance of the finder with the given magnetic field
+  /// need to unpack the magnetic field and return the finder
+  return std::visit(
+      [trackingGeometry, level](auto&& inputField) -> FinderFunction {
+	/// Construct some aliases for the components below
+        using InputMagneticField = typename std::decay_t<decltype(inputField)>::element_type;
+        using MagneticField      = Acts::SharedBField<InputMagneticField>;
+        using Stepper            = Acts::EigenStepper<MagneticField>;
+        using Navigator          = Acts::Navigator;
+        using Propagator         = Acts::Propagator<Stepper, Navigator>;
+        using Finder             = Acts::CombinatorialKalmanFilter
+	                           <Propagator, Updater, Smoother>;
+
+        /// Make the components for the fitter
+        MagneticField field(std::move(inputField));
+        Stepper       stepper(std::move(field));
+        Navigator     navigator(trackingGeometry);
+        navigator.resolvePassive   = false;
+        navigator.resolveMaterial  = true;
+        navigator.resolveSensitive = true;
+        Propagator propagator(std::move(stepper), std::move(navigator));
+        Finder     finder(std::move(propagator),
+                      Acts::getDefaultLogger("CombinatorialKalmanFilter", level));
+
+        /// Build the fitter function
+        return TrkrFindingFunctionImpl<Finder>(std::move(finder));
+      },
+      std::move(magneticField));
+}

--- a/Examples/Algorithms/Fitting/src/TrkrClusterFindingAlgorithmFinderFunction.cpp
+++ b/Examples/Algorithms/Fitting/src/TrkrClusterFindingAlgorithmFinderFunction.cpp
@@ -29,7 +29,7 @@ namespace {
     operator()(
        const std::vector<SourceLink>& sourceLinks,
        const FW::TrackParameters&                          initialParameters,
-       const Acts::CombinatorialKalmanFilterOptions<Acts::VoidBranchStopper>&       options) const
+       const Acts::CombinatorialKalmanFilterOptions<Acts::CKFSourceLinkSelector>&       options) const
     {
       /// Call CombinatorialKalmanFilter findTracks
       return finder.findTracks(sourceLinks, initialParameters, options);


### PR DESCRIPTION
This PR introduces classes that are analogous to the Fitting classes, but use the Combinatorial Kalman Filter (CKF) track finder of Acts instead of the track fitter. The classes are designed similarly to the Acts/Example which calls the track finding on reconstructed tracks, so that the API call to the CKF track finder is similar.