### PR TITLE
remove final to suppress warning by default macro

### DIFF
--- a/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
+++ b/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp
@@ -31,7 +31,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 namespace FW{
 
-  class TrkrClusterFindingAlgorithm final : public FW::BareAlgorithm
+  class TrkrClusterFindingAlgorithm : public FW::BareAlgorithm
   {
 
   public:

--- a/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
+++ b/Examples/Algorithms/Fitting/include/ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp
@@ -33,7 +33,7 @@ namespace FW {
  * This class contains the information required to run the Kalman fitter
  * with the TrkrClusterSourceLinks. Based on FW::FittingAlgorithm
  */
-class TrkrClusterFittingAlgorithm final : public FW::BareAlgorithm
+class TrkrClusterFittingAlgorithm : public FW::BareAlgorithm
 {
 public:
   /// Construct some aliases to be used for the fitting results


### PR DESCRIPTION
Doesn't matter as there won't be anything inheriting from these classes anyway.