### PR TITLE
Update event data objects to reflect svtx-acts object interactions

### DIFF
--- a/Examples/Framework/include/ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp
@@ -43,11 +43,13 @@ struct TrkrClusterMultiTrajectory {
   /// @param parameters The fitted track parameters indexed by trajectory entry
   /// index
   TrkrClusterMultiTrajectory(const Acts::MultiTrajectory<SourceLink>& multiTraj,
-                     const std::vector<size_t>& tTips,
-                     const IndexedParams& parameters)
+			     const std::vector<size_t>& tTips,
+			     const IndexedParams& parameters,
+			     const int& vertexId)
       : m_multiTrajectory(multiTraj),
         m_trackTips(tTips),
-        m_trackParameters(parameters) {}
+        m_trackParameters(parameters),
+	m_vertexId(vertexId){}
 
   /// @brief Copy constructor
   ///
@@ -55,7 +57,8 @@ struct TrkrClusterMultiTrajectory {
   TrkrClusterMultiTrajectory(const TrkrClusterMultiTrajectory& rhs)
       : m_multiTrajectory(rhs.m_multiTrajectory),
         m_trackTips(rhs.m_trackTips),
-        m_trackParameters(rhs.m_trackParameters) {}
+        m_trackParameters(rhs.m_trackParameters),
+	m_vertexId(rhs.m_vertexId){}
 
   /// @brief Copy move constructor
   ///
@@ -63,8 +66,9 @@ struct TrkrClusterMultiTrajectory {
   TrkrClusterMultiTrajectory(TrkrClusterMultiTrajectory&& rhs)
       : m_multiTrajectory(std::move(rhs.m_multiTrajectory)),
         m_trackTips(std::move(rhs.m_trackTips)),
-        m_trackParameters(std::move(rhs.m_trackParameters)) {}
-
+        m_trackParameters(std::move(rhs.m_trackParameters)),
+	m_vertexId(std::move(rhs.m_vertexId)){}
+  
   /// @brief Default destructor
   ///
   ~TrkrClusterMultiTrajectory() = default;
@@ -76,6 +80,7 @@ struct TrkrClusterMultiTrajectory {
     m_multiTrajectory = rhs.m_multiTrajectory;
     m_trackTips = rhs.m_trackTips;
     m_trackParameters = rhs.m_trackParameters;
+    m_vertexId = rhs.m_vertexId;
     return *this;
   }
 
@@ -86,6 +91,7 @@ struct TrkrClusterMultiTrajectory {
     m_multiTrajectory = std::move(rhs.m_multiTrajectory);
     m_trackTips = std::move(rhs.m_trackTips);
     m_trackParameters = std::move(rhs.m_trackParameters);
+    m_vertexId = std::move(rhs.m_vertexId);
     return *this;
   }
 
@@ -142,6 +148,8 @@ struct TrkrClusterMultiTrajectory {
 
   // The fitted parameters at the provided surface for individual trajectories
   IndexedParams m_trackParameters = {};
+  
+  unsigned int m_vertexId = 9999;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/include/ActsExamples/EventData/TrkrClusterSourceLink.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/TrkrClusterSourceLink.hpp
@@ -22,11 +22,11 @@ class TrkrClusterSourceLink
 
   /// Instantiate with a hitid, associated surface, and values that actually
   /// make the measurement. Acts requires the surface be available in this class
-  TrkrClusterSourceLink(unsigned int hitid,
+  TrkrClusterSourceLink(uint64_t cluskey,
 			std::shared_ptr<const Acts::Surface> surface,
 			Acts::BoundVector loc,
 			Acts::BoundMatrix cov)
-    : m_hitid(hitid)
+    : m_cluskey(cluskey)
     , m_surface(surface)
     , m_geoId(surface->geometryId())
     , m_loc(loc)
@@ -79,9 +79,9 @@ class TrkrClusterSourceLink
 	  };
   }
 
-  unsigned int hitID() const
+  uint64_t cluskey() const
   {
-    return m_hitid;
+    return m_cluskey;
   }
 
 
@@ -89,7 +89,7 @@ private:
 
   /// Hitindex corresponding to hitID and the corresponding 
   /// surface to which it belongs to
-  unsigned int m_hitid;
+  uint64_t m_cluskey;
   std::shared_ptr<const Acts::Surface> m_surface;
   Acts::GeometryIdentifier m_geoId;
 
@@ -103,7 +103,7 @@ private:
   friend constexpr bool
   operator==(const TrkrClusterSourceLink& lhs, const TrkrClusterSourceLink& rhs)
   {
-    return lhs.m_hitid == rhs.m_hitid;
+    return lhs.m_cluskey == rhs.m_cluskey;
   }
 
 };


### PR DESCRIPTION
This PR adds some member variables to the sPHENIX EventData classes. It should not be merged until the corresponding coresoftware [PR](https://github.com/sPHENIX-Collaboration/coresoftware/pull/1111) is merged.