### PR TITLE
Add helix cut for misaligned tracks

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -459,7 +459,7 @@ void SeedFinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
 
         // sqrt(S2)/B = 2 * helixradius
         // calculated radius must not be smaller than minimum radius
-        if (S2 < B2 * m_config.minHelixDiameter2) {
+        if (S2 < B2 * m_config.minHelixDiameter2 * m_config.helixcut) {
           continue;
         }
 

--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -154,6 +154,9 @@ struct SeedFinderConfig {
   int nTrplPerSpBLimit = 100;
   int nAvgTrplPerSpBLimit = 2;
 
+  // sPHENIX quantities for alignment bypassing cuts
+  float helixcut = 1.;
+
   // Delegates for accessors to detailed information on double measurement that
   // produced the space point.
   // This is mainly referring to space points produced when combining


### PR DESCRIPTION
Adds a configurable parameter to bypass the helix diameter cut in the seeder, which is poorly estimated when surfaces are misaligned and track parameters can't be reliably estimated.